### PR TITLE
Replace .call with a normal method call (faster)

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,6 +43,6 @@ function EngineServer(onConnection) {
 
 function invoke(method) {
     return function (obj) {
-        return obj[method].call(obj)
+        return (obj[method])()
     }
 }


### PR DESCRIPTION
Just a little patch, the invoke method would be faster if you avoided using `.call` and assigning a scope manually and simply just called the method (since you aren't passing any arguments anyway). The scope will still be as you expect it

``` javascript
var foo = {bar: function(){ return this; }}

console.log(foo['bar']() === foo) // true
```
